### PR TITLE
[PR] Support metal and accelerate based post-processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+
+.DS_Store

--- a/DepthPrediction-CoreML.xcodeproj/project.pbxproj
+++ b/DepthPrediction-CoreML.xcodeproj/project.pbxproj
@@ -12,13 +12,20 @@
 		71BBE01C22E2D2EB00E74F11 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 71BBE01A22E2D2EB00E74F11 /* Main.storyboard */; };
 		71BBE01E22E2D2EC00E74F11 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 71BBE01D22E2D2EC00E74F11 /* Assets.xcassets */; };
 		71BBE02122E2D2EC00E74F11 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 71BBE01F22E2D2EC00E74F11 /* LaunchScreen.storyboard */; };
-		71BBE02922E2D3A900E74F11 /* FCRN.mlmodel in Sources */ = {isa = PBXBuildFile; fileRef = 71BBE02822E2D3A900E74F11 /* FCRN.mlmodel */; };
-		71BBE02B22E2D3AD00E74F11 /* FCRNFP16.mlmodel in Sources */ = {isa = PBXBuildFile; fileRef = 71BBE02A22E2D3AD00E74F11 /* FCRNFP16.mlmodel */; };
 		71BBE02E22E2D4D300E74F11 /* DrawingHeatmapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BBE02D22E2D4D300E74F11 /* DrawingHeatmapView.swift */; };
 		71BBE03022E2D83600E74F11 /* HeatmapPostProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BBE02F22E2D83600E74F11 /* HeatmapPostProcessor.swift */; };
 		71BBE03222E2E9F200E74F11 /* LiveImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BBE03122E2E9F200E74F11 /* LiveImageViewController.swift */; };
 		71BBE03422E2EB8700E74F11 /* Measure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BBE03322E2EB8700E74F11 /* Measure.swift */; };
 		71BBE03622E2EC1400E74F11 /* VideoCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BBE03522E2EC1400E74F11 /* VideoCapture.swift */; };
+		C4A2A2BD2568DB0C001BE0BB /* LiveMetalImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4A2A2BC2568DB0C001BE0BB /* LiveMetalImageViewController.swift */; };
+		C4A2A2C02568DB1E001BE0BB /* FCRNFP16.mlmodel in Sources */ = {isa = PBXBuildFile; fileRef = C4A2A2BF2568DB1E001BE0BB /* FCRNFP16.mlmodel */; };
+		C4A2A2C42568DB3F001BE0BB /* FCRN.mlmodel in Sources */ = {isa = PBXBuildFile; fileRef = C4A2A2C32568DB3F001BE0BB /* FCRN.mlmodel */; };
+		C4A2A2C82568DBB5001BE0BB /* MetalRenderingDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4A2A2C72568DBB5001BE0BB /* MetalRenderingDevice.swift */; };
+		C4A2A2CC2568DBCA001BE0BB /* Texture.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4A2A2CB2568DBCA001BE0BB /* Texture.swift */; };
+		C4A2A2CF2568DBDD001BE0BB /* Maths.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4A2A2CE2568DBDD001BE0BB /* Maths.swift */; };
+		C4A2A2D22568DBE6001BE0BB /* Shaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = C4A2A2D12568DBE6001BE0BB /* Shaders.metal */; };
+		C4A2A2D82568DC2B001BE0BB /* MetalVideoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4A2A2D72568DC2B001BE0BB /* MetalVideoView.swift */; };
+		C4A2A2DB2568DC7C001BE0BB /* DepthmapTextureGenerater.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4A2A2DA2568DC7C001BE0BB /* DepthmapTextureGenerater.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -29,13 +36,20 @@
 		71BBE01D22E2D2EC00E74F11 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		71BBE02022E2D2EC00E74F11 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		71BBE02222E2D2EC00E74F11 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		71BBE02822E2D3A900E74F11 /* FCRN.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; path = FCRN.mlmodel; sourceTree = "<group>"; };
-		71BBE02A22E2D3AD00E74F11 /* FCRNFP16.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; path = FCRNFP16.mlmodel; sourceTree = "<group>"; };
 		71BBE02D22E2D4D300E74F11 /* DrawingHeatmapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingHeatmapView.swift; sourceTree = "<group>"; };
 		71BBE02F22E2D83600E74F11 /* HeatmapPostProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeatmapPostProcessor.swift; sourceTree = "<group>"; };
 		71BBE03122E2E9F200E74F11 /* LiveImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveImageViewController.swift; sourceTree = "<group>"; };
 		71BBE03322E2EB8700E74F11 /* Measure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Measure.swift; sourceTree = "<group>"; };
 		71BBE03522E2EC1400E74F11 /* VideoCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCapture.swift; sourceTree = "<group>"; };
+		C4A2A2BC2568DB0C001BE0BB /* LiveMetalImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveMetalImageViewController.swift; sourceTree = "<group>"; };
+		C4A2A2BF2568DB1E001BE0BB /* FCRNFP16.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; path = FCRNFP16.mlmodel; sourceTree = "<group>"; };
+		C4A2A2C32568DB3F001BE0BB /* FCRN.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; path = FCRN.mlmodel; sourceTree = "<group>"; };
+		C4A2A2C72568DBB5001BE0BB /* MetalRenderingDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetalRenderingDevice.swift; sourceTree = "<group>"; };
+		C4A2A2CB2568DBCA001BE0BB /* Texture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Texture.swift; sourceTree = "<group>"; };
+		C4A2A2CE2568DBDD001BE0BB /* Maths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Maths.swift; sourceTree = "<group>"; };
+		C4A2A2D12568DBE6001BE0BB /* Shaders.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = Shaders.metal; sourceTree = "<group>"; };
+		C4A2A2D72568DC2B001BE0BB /* MetalVideoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetalVideoView.swift; sourceTree = "<group>"; };
+		C4A2A2DA2568DC7C001BE0BB /* DepthmapTextureGenerater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DepthmapTextureGenerater.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -70,12 +84,14 @@
 			children = (
 				71BBE01A22E2D2EB00E74F11 /* Main.storyboard */,
 				71BBE01622E2D2EB00E74F11 /* AppDelegate.swift */,
+				C4A2A2BC2568DB0C001BE0BB /* LiveMetalImageViewController.swift */,
 				71BBE03122E2E9F200E74F11 /* LiveImageViewController.swift */,
 				71BBE01822E2D2EB00E74F11 /* StillImageViewController.swift */,
 				71BBE02D22E2D4D300E74F11 /* DrawingHeatmapView.swift */,
 				71BBE02F22E2D83600E74F11 /* HeatmapPostProcessor.swift */,
 				71BBE03522E2EC1400E74F11 /* VideoCapture.swift */,
 				71BBE03322E2EB8700E74F11 /* Measure.swift */,
+				C4A2A2C62568DBA6001BE0BB /* MetalCamera */,
 				71BBE02C22E2D3B300E74F11 /* mlmodel */,
 				71BBE01D22E2D2EC00E74F11 /* Assets.xcassets */,
 				71BBE01F22E2D2EC00E74F11 /* LaunchScreen.storyboard */,
@@ -87,10 +103,39 @@
 		71BBE02C22E2D3B300E74F11 /* mlmodel */ = {
 			isa = PBXGroup;
 			children = (
-				71BBE02822E2D3A900E74F11 /* FCRN.mlmodel */,
-				71BBE02A22E2D3AD00E74F11 /* FCRNFP16.mlmodel */,
+				C4A2A2BF2568DB1E001BE0BB /* FCRNFP16.mlmodel */,
+				C4A2A2C32568DB3F001BE0BB /* FCRN.mlmodel */,
 			);
 			path = mlmodel;
+			sourceTree = "<group>";
+		};
+		C4A2A2C62568DBA6001BE0BB /* MetalCamera */ = {
+			isa = PBXGroup;
+			children = (
+				C4A2A2C72568DBB5001BE0BB /* MetalRenderingDevice.swift */,
+				C4A2A2D72568DC2B001BE0BB /* MetalVideoView.swift */,
+				C4A2A2DA2568DC7C001BE0BB /* DepthmapTextureGenerater.swift */,
+				C4A2A2CB2568DBCA001BE0BB /* Texture.swift */,
+				C4A2A2D42568DBEB001BE0BB /* Shaders */,
+				C4A2A2D52568DBF5001BE0BB /* Utils */,
+			);
+			path = MetalCamera;
+			sourceTree = "<group>";
+		};
+		C4A2A2D42568DBEB001BE0BB /* Shaders */ = {
+			isa = PBXGroup;
+			children = (
+				C4A2A2D12568DBE6001BE0BB /* Shaders.metal */,
+			);
+			path = Shaders;
+			sourceTree = "<group>";
+		};
+		C4A2A2D52568DBF5001BE0BB /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				C4A2A2CE2568DBDD001BE0BB /* Maths.swift */,
+			);
+			path = Utils;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -165,13 +210,20 @@
 			buildActionMask = 2147483647;
 			files = (
 				71BBE01922E2D2EB00E74F11 /* StillImageViewController.swift in Sources */,
-				71BBE02922E2D3A900E74F11 /* FCRN.mlmodel in Sources */,
+				C4A2A2D82568DC2B001BE0BB /* MetalVideoView.swift in Sources */,
+				C4A2A2CC2568DBCA001BE0BB /* Texture.swift in Sources */,
+				C4A2A2C42568DB3F001BE0BB /* FCRN.mlmodel in Sources */,
+				C4A2A2C02568DB1E001BE0BB /* FCRNFP16.mlmodel in Sources */,
+				C4A2A2BD2568DB0C001BE0BB /* LiveMetalImageViewController.swift in Sources */,
 				71BBE03422E2EB8700E74F11 /* Measure.swift in Sources */,
 				71BBE03222E2E9F200E74F11 /* LiveImageViewController.swift in Sources */,
 				71BBE03622E2EC1400E74F11 /* VideoCapture.swift in Sources */,
+				C4A2A2D22568DBE6001BE0BB /* Shaders.metal in Sources */,
+				C4A2A2DB2568DC7C001BE0BB /* DepthmapTextureGenerater.swift in Sources */,
+				C4A2A2C82568DBB5001BE0BB /* MetalRenderingDevice.swift in Sources */,
+				C4A2A2CF2568DBDD001BE0BB /* Maths.swift in Sources */,
 				71BBE02E22E2D4D300E74F11 /* DrawingHeatmapView.swift in Sources */,
 				71BBE03022E2D83600E74F11 /* HeatmapPostProcessor.swift in Sources */,
-				71BBE02B22E2D3AD00E74F11 /* FCRNFP16.mlmodel in Sources */,
 				71BBE01722E2D2EB00E74F11 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/DepthPrediction-CoreML/Base.lproj/Main.storyboard
+++ b/DepthPrediction-CoreML/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="gnV-An-c8Y">
-    <device id="retina6_1" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="gnV-An-c8Y">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -33,6 +33,7 @@
                                 </constraints>
                             </view>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="Lag-ag-fAw" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="0zP-h7-3q2"/>
@@ -42,7 +43,6 @@
                             <constraint firstItem="HYX-v1-DXe" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="p8z-1U-j7L"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="Lag-ag-fAw" secondAttribute="bottom" constant="20" id="qUc-qa-m18"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                     <navigationItem key="navigationItem" id="3dt-C9-H39">
                         <barButtonItem key="rightBarButtonItem" systemItem="camera" id="UJn-Qj-WLu">
@@ -124,6 +124,7 @@
                                 </constraints>
                             </view>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="gdC-gL-MVz"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="gdC-gL-MVz" firstAttribute="trailing" secondItem="ULK-nV-M8I" secondAttribute="trailing" id="0Pg-eI-p99"/>
@@ -136,7 +137,6 @@
                             <constraint firstItem="ULK-nV-M8I" firstAttribute="leading" secondItem="gdC-gL-MVz" secondAttribute="leading" id="Uel-qX-Tsk"/>
                             <constraint firstItem="qKp-wK-9za" firstAttribute="centerX" secondItem="noJ-LW-AEx" secondAttribute="centerX" id="l34-hb-qyH"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="gdC-gL-MVz"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="Live Image" id="EZu-KF-uOx"/>
                     <connections>
@@ -150,6 +150,97 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Tty-tA-CDZ" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1367" y="137"/>
+        </scene>
+        <!--GPU Live-->
+        <scene sceneID="NvH-RO-1jg">
+            <objects>
+                <viewController id="bdS-su-R7R" customClass="LiveMetalImageViewController" customModule="DepthPrediction_CoreML" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="wWU-Ta-JDP">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PjL-w2-d4f">
+                                <rect key="frame" x="0.0" y="72" width="414" height="552"/>
+                                <color key="backgroundColor" red="0.86274509799999999" green="0.63529411759999999" blue="0.86274509799999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="PjL-w2-d4f" secondAttribute="height" multiplier="3:4" priority="750" id="WVo-dG-jSU"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vCR-YP-fij">
+                                <rect key="frame" x="0.0" y="44" width="414" height="24"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Inference: xxx ms" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="btn-bJ-HQ5">
+                                        <rect key="frame" x="16" y="8" width="120.5" height="8"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <fontDescription key="fontDescription" name="Courier-Bold" family="Courier" pointSize="9"/>
+                                        <color key="textColor" red="0.0" green="0.98106676339999999" blue="0.57369142770000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Execution: xxx ms" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="6KM-L9-GSe">
+                                        <rect key="frame" x="146.5" y="7.5" width="121" height="9"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <fontDescription key="fontDescription" name="Courier-Bold" family="Courier" pointSize="9"/>
+                                        <color key="textColor" red="0.0" green="0.98106676339999999" blue="0.57369142770000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="fps: xx" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="c4u-Nn-Res">
+                                        <rect key="frame" x="277.5" y="7.5" width="120.5" height="9"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <fontDescription key="fontDescription" name="Courier-Bold" family="Courier" pointSize="9"/>
+                                        <color key="textColor" red="0.0" green="0.98106676339999999" blue="0.57369142770000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.80182470029999997" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="c4u-Nn-Res" firstAttribute="width" secondItem="btn-bJ-HQ5" secondAttribute="width" id="4Ph-0G-49W"/>
+                                    <constraint firstItem="btn-bJ-HQ5" firstAttribute="top" secondItem="vCR-YP-fij" secondAttribute="top" constant="8" id="9ef-Kl-alL"/>
+                                    <constraint firstItem="6KM-L9-GSe" firstAttribute="centerY" secondItem="btn-bJ-HQ5" secondAttribute="centerY" id="Psc-nw-YKN"/>
+                                    <constraint firstItem="btn-bJ-HQ5" firstAttribute="leading" secondItem="vCR-YP-fij" secondAttribute="leading" constant="16" id="Ubn-FB-hwr"/>
+                                    <constraint firstItem="6KM-L9-GSe" firstAttribute="width" secondItem="btn-bJ-HQ5" secondAttribute="width" id="X6d-4f-eed"/>
+                                    <constraint firstAttribute="bottom" secondItem="btn-bJ-HQ5" secondAttribute="bottom" constant="8" id="YPu-uj-5vg"/>
+                                    <constraint firstItem="btn-bJ-HQ5" firstAttribute="centerY" secondItem="vCR-YP-fij" secondAttribute="centerY" id="cbD-Uf-tiu"/>
+                                    <constraint firstItem="6KM-L9-GSe" firstAttribute="leading" secondItem="btn-bJ-HQ5" secondAttribute="trailing" constant="10" id="f9H-IX-AKi"/>
+                                    <constraint firstAttribute="trailing" secondItem="c4u-Nn-Res" secondAttribute="trailing" constant="16" id="kbY-Pe-yY5"/>
+                                    <constraint firstItem="c4u-Nn-Res" firstAttribute="leading" secondItem="6KM-L9-GSe" secondAttribute="trailing" constant="10" id="oba-MD-g7C"/>
+                                    <constraint firstAttribute="height" constant="24" id="qqG-Yt-Nje"/>
+                                    <constraint firstItem="c4u-Nn-Res" firstAttribute="centerY" secondItem="vCR-YP-fij" secondAttribute="centerY" id="unL-QE-EWr"/>
+                                </constraints>
+                            </view>
+                            <mtkView contentMode="scaleToFill" colorPixelFormat="BGRA8Unorm" depthStencilPixelFormat="Depth32Float" translatesAutoresizingMaskIntoConstraints="NO" id="bre-E3-kcp" customClass="MetalVideoView" customModule="DepthPrediction_CoreML" customModuleProvider="target">
+                                <rect key="frame" x="94" y="628" width="226" height="181"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="bre-E3-kcp" secondAttribute="height" multiplier="160:128" id="IrL-1S-kG0"/>
+                                </constraints>
+                            </mtkView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="gVS-MR-fcX"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="vCR-YP-fij" secondAttribute="trailing" id="4kz-I3-dTr"/>
+                            <constraint firstItem="vCR-YP-fij" firstAttribute="leading" secondItem="gVS-MR-fcX" secondAttribute="leading" id="6wW-Bh-XcN"/>
+                            <constraint firstItem="gVS-MR-fcX" firstAttribute="bottom" secondItem="bre-E3-kcp" secondAttribute="bottom" constant="4" id="7MT-71-jjc"/>
+                            <constraint firstItem="bre-E3-kcp" firstAttribute="centerX" secondItem="wWU-Ta-JDP" secondAttribute="centerX" id="Bgh-zw-fIj"/>
+                            <constraint firstItem="vCR-YP-fij" firstAttribute="top" secondItem="gVS-MR-fcX" secondAttribute="top" id="Mfi-vh-kkP"/>
+                            <constraint firstAttribute="trailing" secondItem="PjL-w2-d4f" secondAttribute="trailing" id="PBS-uO-iXq"/>
+                            <constraint firstItem="PjL-w2-d4f" firstAttribute="top" secondItem="vCR-YP-fij" secondAttribute="bottom" constant="4" id="aAm-fM-XmU"/>
+                            <constraint firstItem="PjL-w2-d4f" firstAttribute="width" secondItem="PjL-w2-d4f" secondAttribute="height" multiplier="3:4" priority="750" id="dex-OJ-I6d"/>
+                            <constraint firstItem="bre-E3-kcp" firstAttribute="top" secondItem="PjL-w2-d4f" secondAttribute="bottom" constant="4" id="w2S-Wo-Vcj"/>
+                            <constraint firstItem="PjL-w2-d4f" firstAttribute="leading" secondItem="gVS-MR-fcX" secondAttribute="leading" id="zMU-YG-sND"/>
+                        </constraints>
+                    </view>
+                    <tabBarItem key="tabBarItem" title="GPU Live" id="HOb-PD-X3H"/>
+                    <connections>
+                        <outlet property="depthmapView" destination="bre-E3-kcp" id="eq3-Qk-Wdi"/>
+                        <outlet property="etimeLabel" destination="6KM-L9-GSe" id="fvV-uW-xyC"/>
+                        <outlet property="fpsLabel" destination="c4u-Nn-Res" id="pNS-5d-ShW"/>
+                        <outlet property="inferenceLabel" destination="btn-bJ-HQ5" id="MfP-4O-cIo"/>
+                        <outlet property="videoPreview" destination="PjL-w2-d4f" id="n7p-gc-aQe"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="w3E-GK-ATr" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1367" y="-1203"/>
         </scene>
         <!--Still Image-->
         <scene sceneID="q11-aU-6uU">
@@ -181,6 +272,7 @@
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </tabBar>
                     <connections>
+                        <segue destination="bdS-su-R7R" kind="relationship" relationship="viewControllers" id="Icc-hq-en2"/>
                         <segue destination="edf-aQ-qA1" kind="relationship" relationship="viewControllers" id="b32-fX-2Jc"/>
                         <segue destination="OZJ-yh-xc5" kind="relationship" relationship="viewControllers" id="cqG-lL-EUE"/>
                     </connections>
@@ -190,4 +282,9 @@
             <point key="canvasLocation" x="261" y="-216"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/DepthPrediction-CoreML/LiveMetalImageViewController.swift
+++ b/DepthPrediction-CoreML/LiveMetalImageViewController.swift
@@ -1,0 +1,170 @@
+//
+//  LiveMetalImageViewController.swift
+//  DepthPrediction-CoreML
+//
+//  Created by Doyoung Gwak on 2020/11/21.
+//  Copyright © 2020 Doyoung Gwak. All rights reserved.
+//
+
+import UIKit
+import Vision
+
+class LiveMetalImageViewController: UIViewController {
+
+    // MARK: - UI Properties
+    @IBOutlet weak var videoPreview: UIView!
+    @IBOutlet weak var depthmapView: MetalVideoView!
+    
+    @IBOutlet weak var inferenceLabel: UILabel!
+    @IBOutlet weak var etimeLabel: UILabel!
+    @IBOutlet weak var fpsLabel: UILabel!
+    
+    // MARK: - AV Properties
+    var videoCapture: VideoCapture!
+    
+    // MARK - Core ML model
+    // FCRN(iOS11+), FCRNFP16(iOS11+)
+    let estimationModel = FCRN()
+    
+    // MARK: - Vision Properties
+    var request: VNCoreMLRequest?
+    var visionModel: VNCoreMLModel?
+    
+    // let postprocessor = HeatmapPostProcessor()
+    let depthmapTexutreGenerater = DepthmapTextureGenerater()
+    
+    // MARK: - Performance Measurement Property
+    private let 👨‍🔧 = 📏()
+    
+    // MARK: - View Controller Life Cycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        // setup ml model
+        setUpModel()
+        
+        // setup camera
+        setUpCamera()
+        
+        // setup delegate for performance measurement
+        👨‍🔧.delegate = self
+    }
+    
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.videoCapture.start()
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        self.videoCapture.stop()
+    }
+    
+    // MARK: - Setup Core ML
+    func setUpModel() {
+        if let visionModel = try? VNCoreMLModel(for: estimationModel.model) {
+            self.visionModel = visionModel
+            request = VNCoreMLRequest(model: visionModel, completionHandler: visionRequestDidComplete)
+            request?.imageCropAndScaleOption = .scaleFill
+        } else {
+            fatalError()
+        }
+    }
+    
+    // MARK: - Setup camera
+    func setUpCamera() {
+        videoCapture = VideoCapture()
+        videoCapture.delegate = self
+        videoCapture.fps = 50
+        videoCapture.setUp(sessionPreset: .vga640x480) { success in
+            
+            if success {
+                // UI에 비디오 미리보기 뷰 넣기
+                if let previewLayer = self.videoCapture.previewLayer {
+                    self.videoPreview.layer.addSublayer(previewLayer)
+                    self.resizePreviewLayer()
+                }
+                
+                // 초기설정이 끝나면 라이브 비디오를 시작할 수 있음
+                self.videoCapture.start()
+            }
+        }
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        resizePreviewLayer()
+    }
+    
+    func resizePreviewLayer() {
+        videoCapture.previewLayer?.frame = videoPreview.bounds
+    }
+}
+
+// MARK: - VideoCaptureDelegate
+extension LiveMetalImageViewController: VideoCaptureDelegate {
+    func videoCapture(_ capture: VideoCapture, didCaptureVideoFrame pixelBuffer: CVPixelBuffer?/*, timestamp: CMTime*/) {
+        
+        // the captured image from camera is contained on pixelBuffer
+        if let pixelBuffer = pixelBuffer {
+            // start of measure
+            self.👨‍🔧.🎬👏()
+            
+            // predict!
+            predict(with: pixelBuffer)
+        }
+    }
+}
+
+// MARK: - Inference
+extension LiveMetalImageViewController {
+    // prediction
+    func predict(with pixelBuffer: CVPixelBuffer) {
+        guard let request = request else { fatalError() }
+        
+        // vision framework configures the input size of image following our model's input configuration automatically
+        let handler = VNImageRequestHandler(cvPixelBuffer: pixelBuffer, options: [:])
+        try? handler.perform([request])
+    }
+    
+    // post-processing
+    func visionRequestDidComplete(request: VNRequest, error: Error?) {
+        
+        self.👨‍🔧.🏷(with: "endInference")
+        
+        if let observations = request.results as? [VNCoreMLFeatureValueObservation],
+            let depthmap = observations.first?.featureValue.multiArrayValue {
+            
+            guard let row = depthmap.shape[1] as? Int,
+                let col = depthmap.shape[2] as? Int else {
+                    return
+            }
+            
+            depthmapView.currentTexture = depthmapTexutreGenerater.texture(depthmap, row, col)
+            
+            DispatchQueue.main.async { [weak self] in
+                
+                // end of measure
+                self?.👨‍🔧.🎬🤚()
+            }
+        } else {
+            // end of measure
+            self.👨‍🔧.🎬🤚()
+        }
+    }
+}
+
+// MARK: - 📏(Performance Measurement) Delegate
+extension LiveMetalImageViewController: 📏Delegate {
+    func updateMeasure(inferenceTime: Double, executionTime: Double, fps: Int) {
+        //print(executionTime, fps)
+        self.inferenceLabel.text = "inference: \(Int(inferenceTime*1000.0)) mm"
+        self.etimeLabel.text = "execution: \(Int(executionTime*1000.0)) mm"
+        self.fpsLabel.text = "fps: \(fps)"
+    }
+}

--- a/DepthPrediction-CoreML/MetalCamera/DepthmapTextureGenerater.swift
+++ b/DepthPrediction-CoreML/MetalCamera/DepthmapTextureGenerater.swift
@@ -1,0 +1,111 @@
+//
+//  AlphaBlend.swift → DepthmapTextureGenerater.swift
+//  MetalCamera → DepthPrediction-CoreML
+//
+//  Created by Eric on 2020/06/16.
+//  Updated by Doyoung Gwak on 2020/11/21.
+//
+
+import MetalKit
+import Accelerate
+import CoreML
+
+class DepthmapTextureGenerater: NSObject {
+    
+    private var pipelineState: MTLRenderPipelineState!
+    private var render_target_vertex: MTLBuffer!
+    private var render_target_uniform: MTLBuffer!
+    
+    private func setupPiplineState(_ colorPixelFormat: MTLPixelFormat = .bgra8Unorm, width: Int, height: Int) {
+        do {
+            let rpd = try sharedMetalRenderingDevice.generateRenderPipelineDescriptor("vertex_render_target",
+                                                                                      "depthmap_render_target",
+                                                                                      colorPixelFormat)
+            pipelineState = try sharedMetalRenderingDevice.device.makeRenderPipelineState(descriptor: rpd)
+
+            render_target_vertex = sharedMetalRenderingDevice.makeRenderVertexBuffer(size: CGSize(width: width, height: height))
+            render_target_uniform = sharedMetalRenderingDevice.makeRenderUniformBuffer(CGSize(width: width, height: height))
+        } catch {
+            debugPrint(error)
+        }
+    }
+    
+    func texture(_ depthMap: MLMultiArray, _ row: Int, _ col: Int) -> Texture? {
+        if pipelineState == nil {
+            setupPiplineState(width: col, height: row)
+        }
+
+        let outputTexture = Texture(col, row, textureKey: "depthprediction")
+
+        let renderPassDescriptor = MTLRenderPassDescriptor()
+        let attachment = renderPassDescriptor.colorAttachments[0]
+        attachment?.clearColor = .red
+        attachment?.texture = outputTexture.texture
+        attachment?.loadAction = .clear
+        attachment?.storeAction = .store
+
+        let commandBuffer = sharedMetalRenderingDevice.commandQueue.makeCommandBuffer()
+        let commandEncoder = commandBuffer?.makeRenderCommandEncoder(descriptor: renderPassDescriptor)
+
+        commandEncoder?.setRenderPipelineState(pipelineState)
+
+        commandEncoder?.setVertexBuffer(render_target_vertex, offset: 0, index: 0)
+        commandEncoder?.setVertexBuffer(render_target_uniform, offset: 0, index: 1)
+        
+        // convert Double to Float
+        let length = depthMap.count
+        let doublePtr =  depthMap.dataPointer.bindMemory(to: Double.self, capacity: length)
+        let doubleBuffer = UnsafeBufferPointer(start: doublePtr, count: length)
+        var inputArray = Array(doubleBuffer)
+        var resultArray = [Float](repeating: 0, count: length)
+        let n = vDSP_Length(min(inputArray.count, resultArray.count))
+        var resultPointer: UnsafeMutableBufferPointer<Float>?
+        inputArray.withUnsafeMutableBufferPointer { (inputPointer) -> Void in
+            resultArray.withUnsafeMutableBufferPointer { (outputPointer) -> Void in
+                vDSP_vdpsp(inputPointer.baseAddress!, 1,
+                           outputPointer.baseAddress!, 1, n)
+                resultPointer = outputPointer
+            }
+        }
+        
+        // normalize to 0.0~1.0
+        var maxValue: Float = 0.0
+        vDSP_maxv(resultPointer!.baseAddress!, 1, &maxValue, n)
+        var minValue: Float = 1.0
+        vDSP_minv(resultPointer!.baseAddress!, 1, &minValue, n)
+        var subtracOperanderArray = Array(repeating: minValue, count: Int(n))
+        let floorValue = maxValue - minValue
+        let multiplyOperanderValue = (floorValue == 0.0) ? 0.0 : 1 / (maxValue - minValue)
+        var multiplyOperanderArray = Array(repeating: multiplyOperanderValue, count: Int(n))
+        subtracOperanderArray.withUnsafeMutableBufferPointer { (subtracOperanderPointer) -> Void in
+            multiplyOperanderArray.withUnsafeMutableBufferPointer { (multiplyOperanderPointer) -> Void in
+                vDSP_vsbm(resultPointer!.baseAddress!, 1,
+                          subtracOperanderPointer.baseAddress!, 1,
+                          multiplyOperanderPointer.baseAddress!, 1,
+                          resultPointer!.baseAddress!, 1, n)
+            }
+        }
+
+        let segmentationBuffer = sharedMetalRenderingDevice.device.makeBuffer(bytes: resultPointer!.baseAddress!,
+                                                                              length: resultArray.count * MemoryLayout<Float>.size, // Double가 맞나?, mlmodel output에 나온대로 Double로 변경함
+                                                                              options: [])!
+        commandEncoder?.setFragmentBuffer(segmentationBuffer, offset: 0, index: 0)
+
+        let uniformBuffer = sharedMetalRenderingDevice.device.makeBuffer(bytes: [Int32(col), Int32(row)] as [Int32],
+                                                                         length: 3 * MemoryLayout<Int32>.size,
+                                                                         options: [])!
+        commandEncoder?.setFragmentBuffer(uniformBuffer, offset: 0, index: 1)
+
+        commandEncoder?.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4)
+        commandEncoder?.endEncoding()
+        commandBuffer?.commit()
+
+        return outputTexture
+    }
+}
+
+extension MTLClearColor {
+    static var red: Self {
+        return MTLClearColorMake(1, 0, 0, 1) // r, g, b, a
+    }
+}

--- a/DepthPrediction-CoreML/MetalCamera/MetalRenderingDevice.swift
+++ b/DepthPrediction-CoreML/MetalCamera/MetalRenderingDevice.swift
@@ -1,0 +1,61 @@
+//
+//  MetalRenderingDevice.swift
+//  MetalCamera
+//
+//  Created by Eric on 2020/06/04.
+//
+
+import CoreGraphics
+import Metal
+
+public let sharedMetalRenderingDevice = MetalRenderingDevice()
+
+public class MetalRenderingDevice {
+    public let device: MTLDevice
+    public let commandQueue: MTLCommandQueue
+
+    init() {
+        guard let device = MTLCreateSystemDefaultDevice() else { fatalError("Could not create Metal Device") }
+        self.device = device
+
+        guard let queue = self.device.makeCommandQueue() else { fatalError("Could not create command queue") }
+        self.commandQueue = queue
+    }
+
+    func generateRenderPipelineDescriptor(_ vertexFuncName: String, _ fragmentFuncName: String, _ colorPixelFormat: MTLPixelFormat = .bgra8Unorm) throws -> MTLRenderPipelineDescriptor {
+        let framework = Bundle.main
+        let resource = framework.path(forResource: "default", ofType: "metallib")!
+        let library = try self.device.makeLibrary(filepath: resource)
+
+        let vertex_func = library.makeFunction(name: vertexFuncName)
+        let fragment_func = library.makeFunction(name: fragmentFuncName)
+        let rpd = MTLRenderPipelineDescriptor()
+        rpd.vertexFunction = vertex_func
+        rpd.fragmentFunction = fragment_func
+        rpd.colorAttachments[0].pixelFormat = colorPixelFormat
+
+        return rpd
+    }
+
+    func makeRenderVertexBuffer(_ origin: CGPoint = .zero, size: CGSize) -> MTLBuffer? {
+        let w = size.width, h = size.height
+        let vertices = [
+            Vertex(position: CGPoint(x: origin.x , y: origin.y), textCoord: CGPoint(x: 0, y: 0)),
+            Vertex(position: CGPoint(x: origin.x + w , y: origin.y), textCoord: CGPoint(x: 1, y: 0)),
+            Vertex(position: CGPoint(x: origin.x + 0 , y: origin.y + h), textCoord: CGPoint(x: 0, y: 1)),
+            Vertex(position: CGPoint(x: origin.x + w , y: origin.y + h), textCoord: CGPoint(x: 1, y: 1)),
+        ]
+        return makeRenderVertexBuffer(vertices)
+    }
+
+    func makeRenderVertexBuffer(_ vertices: [Vertex]) -> MTLBuffer? {
+        return self.device.makeBuffer(bytes: vertices, length: MemoryLayout<Vertex>.stride * vertices.count, options: .cpuCacheModeWriteCombined)
+    }
+
+    func makeRenderUniformBuffer(_ size: CGSize) -> MTLBuffer? {
+        let metrix = Matrix.identity
+        metrix.scaling(x: 2 / Float(size.width), y: -2 / Float(size.height), z: 1)
+        metrix.translation(x: -1, y: 1, z: 0)
+        return self.device.makeBuffer(bytes: metrix.m, length: MemoryLayout<Float>.size * 16, options: [])
+    }
+}

--- a/DepthPrediction-CoreML/MetalCamera/MetalVideoView.swift
+++ b/DepthPrediction-CoreML/MetalCamera/MetalVideoView.swift
@@ -1,0 +1,79 @@
+//
+//  MetalVideoView.swift
+//  MetalCamera
+//
+//  Created by Eric on 2020/06/04.
+//
+
+import Foundation
+import MetalKit
+
+public class MetalVideoView: MTKView {
+    public var currentTexture: Texture? {
+        willSet (newValue) {
+            guard let texture = newValue else { return }
+            drawableSize = CGSize(width: texture.texture.width, height: texture.texture.height)
+        }
+    }
+
+    private var pipelineState: MTLRenderPipelineState!
+    private var render_target_vertex: MTLBuffer!
+    private var render_target_uniform: MTLBuffer!
+
+    public required init(coder: NSCoder) {
+        super.init(coder: coder)
+
+        setup()
+    }
+
+    private func setup() {
+        self.device = sharedMetalRenderingDevice.device
+
+        isOpaque = false
+        setupTargetUniforms()
+
+        do {
+            try setupPiplineState()
+        } catch {
+            fatalError("Metal initialize failed: \(error.localizedDescription)")
+        }
+    }
+
+    func setupTargetUniforms() {
+        let size = drawableSize
+        render_target_vertex = sharedMetalRenderingDevice.makeRenderVertexBuffer(size: size)
+        render_target_uniform = sharedMetalRenderingDevice.makeRenderUniformBuffer(size)
+    }
+
+    private func setupPiplineState() throws {
+        let rpd = try sharedMetalRenderingDevice.generateRenderPipelineDescriptor("vertex_render_target",
+                                                                                  "fragment_render_target",
+                                                                                  colorPixelFormat)
+        pipelineState = try sharedMetalRenderingDevice.device.makeRenderPipelineState(descriptor: rpd)
+    }
+
+    public override func draw(_ rect:CGRect) {
+        if let currentDrawable = self.currentDrawable, let imageTexture = currentTexture {
+            let renderPassDescriptor = MTLRenderPassDescriptor()
+            let attachment = renderPassDescriptor.colorAttachments[0]
+            attachment?.clearColor = clearColor
+            attachment?.texture = currentDrawable.texture
+            attachment?.loadAction = .clear
+            attachment?.storeAction = .store
+
+            let commandBuffer = sharedMetalRenderingDevice.commandQueue.makeCommandBuffer()
+            let commandEncoder = commandBuffer?.makeRenderCommandEncoder(descriptor: renderPassDescriptor)
+
+            commandEncoder?.setRenderPipelineState(pipelineState)
+
+            commandEncoder?.setVertexBuffer(render_target_vertex, offset: 0, index: 0)
+            commandEncoder?.setVertexBuffer(render_target_uniform, offset: 0, index: 1)
+            commandEncoder?.setFragmentTexture(imageTexture.texture, index: 0)
+            commandEncoder?.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4)
+
+            commandEncoder?.endEncoding()
+            commandBuffer?.present(currentDrawable)
+            commandBuffer?.commit()
+        }
+    }
+}

--- a/DepthPrediction-CoreML/MetalCamera/Shaders/Shaders.metal
+++ b/DepthPrediction-CoreML/MetalCamera/Shaders/Shaders.metal
@@ -1,0 +1,67 @@
+#include <metal_stdlib>
+using namespace metal;
+
+struct Vertex {
+    float4 position [[position]];
+    float2 text_coord;
+};
+
+struct TwoInputVertex
+{
+    float4 position [[position]];
+    float2 textureCoordinate [[user(texturecoord)]];
+    float2 textureCoordinate2 [[user(texturecoord2)]];
+};
+
+struct Uniforms {
+    float4x4 scaleMatrix;
+};
+
+vertex Vertex vertex_render_target(constant Vertex *vertexes [[ buffer(0) ]],
+                                   constant Uniforms &uniforms [[ buffer(1) ]],
+                                   uint vid [[vertex_id]])
+{
+    Vertex out = vertexes[vid];
+    out.position = uniforms.scaleMatrix * out.position;// * in.position;
+    return out;
+};
+
+
+fragment float4 fragment_render_target(Vertex vertex_data [[ stage_in ]],
+                                       texture2d<float> tex2d [[ texture(0) ]])
+{
+    constexpr sampler textureSampler(mag_filter::linear, min_filter::linear);
+    float4 color = float4(tex2d.sample(textureSampler, vertex_data.text_coord));
+    return color;
+};
+
+fragment float4 gray_fragment_render_target(Vertex vertex_data [[ stage_in ]],
+                                            texture2d<float> tex2d [[ texture(0) ]])
+{
+    constexpr sampler textureSampler(mag_filter::linear, min_filter::linear);
+    float4 color = float4(tex2d.sample(textureSampler, vertex_data.text_coord));
+    float gray = (color[0] + color[1] + color[2])/3;
+    return float4(gray, gray, gray, 1.0);
+};
+
+typedef struct
+{
+    float depth;
+} DepthmapValue;
+
+typedef struct
+{
+    int32_t width;
+    int32_t height;
+} DepthmapUniform;
+
+fragment float4 depthmap_render_target(Vertex vertex_data [[ stage_in ]],
+                                           constant DepthmapValue *depthmap [[ buffer(0) ]],
+                                           constant DepthmapUniform& uniform [[ buffer(1) ]])
+
+{
+    int index = int(vertex_data.position.x) + int(vertex_data.position.y) * uniform.width;
+    float depthValue = 1.0 - depthmap[index].depth;
+    return float4(depthValue, depthValue, depthValue, 1);
+};
+

--- a/DepthPrediction-CoreML/MetalCamera/Texture.swift
+++ b/DepthPrediction-CoreML/MetalCamera/Texture.swift
@@ -1,0 +1,34 @@
+//
+//  Texture.swift
+//  MetalCamera
+//
+//  Created by Eric on 2020/06/06.
+//
+
+import Foundation
+import AVFoundation
+
+public class Texture {
+    let texture: MTLTexture
+    let textureKey: String
+
+    public init(texture: MTLTexture, textureKey: String = "") {
+        self.texture = texture
+        self.textureKey = textureKey
+    }
+
+    public init(_ width: Int, _ height: Int, pixelFormat: MTLPixelFormat = .bgra8Unorm, textureKey: String = "") {
+        let textureDescriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .bgra8Unorm,
+                                                                         width: width,
+                                                                         height: height,
+                                                                         mipmapped: false)
+        textureDescriptor.usage = [.renderTarget, .shaderRead, .shaderWrite]
+
+        guard let newTexture = sharedMetalRenderingDevice.device.makeTexture(descriptor: textureDescriptor) else {
+            fatalError("Could not create texture of size: (\(width), \(height))")
+        }
+
+        self.texture = newTexture
+        self.textureKey = textureKey
+    }
+}

--- a/DepthPrediction-CoreML/MetalCamera/Utils/Maths.swift
+++ b/DepthPrediction-CoreML/MetalCamera/Utils/Maths.swift
@@ -1,0 +1,166 @@
+//
+//  Maths.swift
+//  MetalRecorder
+//
+//  Created by Eric on 2020/05/30.
+//  Copyright © 2020 Eric. All rights reserved.
+//
+
+import Foundation
+import CoreGraphics
+import simd
+
+struct Vertex {
+    var position: vector_float4
+    var textCoord: vector_float2
+
+    init(position: CGPoint, textCoord: CGPoint) {
+        self.position = position.toFloat4()
+        self.textCoord = textCoord.toFloat2()
+    }
+}
+
+struct Uniforms {
+    var scaleMatrix: [Float]
+    init(scale: Float = 1, drawableSize: CGSize) {
+        scaleMatrix = Matrix.identity.scaling(x:  0.5,  y: 0.5, z: 1).m
+    }
+}
+
+class Matrix {
+
+    private(set) var m: [Float]
+
+    static var identity = Matrix()
+
+    private init() {
+        m = [1, 0, 0, 0,
+             0, 1, 0, 0,
+             0, 0, 1, 0,
+             0, 0, 0, 1
+        ]
+    }
+
+    @discardableResult
+    func translation(x: Float, y: Float, z: Float) -> Matrix {
+        m[12] = x
+        m[13] = y
+        m[14] = z
+        return self
+    }
+
+    @discardableResult
+    func scaling(x: Float, y: Float, z: Float)  -> Matrix  {
+        m[0] = x
+        m[5] = y
+        m[10] = z
+        return self
+    }
+}
+
+// MARK: - Point Utils
+extension CGPoint {
+
+    static func middle(p1: CGPoint, p2: CGPoint) -> CGPoint {
+        return CGPoint(x: (p1.x + p2.x) * 0.5, y: (p1.y + p2.y) * 0.5)
+    }
+
+    func distance(to other: CGPoint) -> CGFloat {
+        let p = pow(x - other.x, 2) + pow(y - other.y, 2)
+        return sqrt(p)
+    }
+
+    func angel(to other: CGPoint = .zero) -> CGFloat {
+        let point = self - other
+        if y == 0 {
+            return x >= 0 ? 0 : CGFloat.pi
+        }
+        return -CGFloat(atan2f(Float(point.y), Float(point.x)))
+    }
+
+    func toFloat4(z: CGFloat = 0, w: CGFloat = 1) -> vector_float4 {
+        return [Float(x), Float(y), Float(z) ,Float(w)]
+    }
+
+    func toFloat2() -> vector_float2 {
+        return [Float(x), Float(y)]
+    }
+
+    func offsetedBy(x: CGFloat = 0, y: CGFloat = 0) -> CGPoint {
+        var point = self
+        point.x += x
+        point.y += y
+        return point
+    }
+
+    func rotatedBy(_ angle: CGFloat, anchor: CGPoint) -> CGPoint {
+        let point = self - anchor
+        let a = Double(-angle)
+        let x = Double(point.x)
+        let y = Double(point.y)
+        let x_ = x * cos(a) - y * sin(a);
+        let y_ = x * sin(a) + y * cos(a);
+        return CGPoint(x: CGFloat(x_), y: CGFloat(y_)) + anchor
+    }
+}
+
+func +(lhs: CGPoint, rhs: CGPoint) -> CGPoint {
+    return CGPoint(x: lhs.x + rhs.x, y: lhs.y + rhs.y)
+}
+
+func +=(lhs: inout CGPoint, rhs: CGPoint) {
+    lhs = lhs + rhs
+}
+
+func -(lhs: CGPoint, rhs: CGPoint) -> CGPoint {
+    return CGPoint(x: lhs.x - rhs.x, y: lhs.y - rhs.y)
+}
+
+func *(lhs: CGPoint, rhs: CGFloat) -> CGPoint {
+    return CGPoint(x: lhs.x * rhs, y: lhs.y * rhs)
+}
+
+func /(lhs: CGPoint, rhs: CGFloat) -> CGPoint {
+    return CGPoint(x: lhs.x / rhs, y: lhs.y / rhs)
+}
+
+func +(lhs: CGSize, rhs: CGSize) -> CGSize {
+    return CGSize(width: lhs.width + rhs.width, height: lhs.height + rhs.height)
+}
+
+func *(lhs: CGSize, rhs: CGFloat) -> CGSize {
+    return CGSize(width: lhs.width * rhs, height: lhs.height * rhs)
+}
+
+func /(lhs: CGSize, rhs: CGFloat) -> CGSize {
+    return CGSize(width: lhs.width / rhs, height: lhs.height / rhs)
+}
+
+func +(lhs: CGPoint, rhs: CGSize) -> CGPoint {
+    return CGPoint(x: lhs.x + rhs.width, y: lhs.y + rhs.height)
+}
+
+func -(lhs: CGPoint, rhs: CGSize) -> CGPoint {
+    return CGPoint(x: lhs.x - rhs.width, y: lhs.y - rhs.height)
+}
+
+func *(lhs: CGPoint, rhs: CGSize) -> CGPoint {
+    return CGPoint(x: lhs.x * rhs.width, y: lhs.y * rhs.height)
+}
+
+func /(lhs: CGPoint, rhs: CGSize) -> CGPoint {
+    return CGPoint(x: lhs.x / rhs.width, y: lhs.y / rhs.height)
+}
+
+
+extension Comparable {
+    func valueBetween(min: Self, max: Self) -> Self {
+        if self > max {
+            return max
+        } else if self < min {
+            return min
+        }
+        return self
+    }
+}
+

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project is Depth Prediction on iOS with Core ML.<br>If you are interested i
 
 | GIF demo 1 | Screenshot 1 | Screenshot 2 | Screenshot 3 | Screenshot 4 |
 | ------------ | ------------ | ------------ | ------------ | ------------ |
-| ![](resource/IMG_0129.gif) | ![](resource/IMG_3623.PNG) | ![](resource/IMG_3626.PNG) | ![](resource/IMG_3627.PNG) | ![](resource/IMG_3629.PNG) |
+| <img src="https://user-images.githubusercontent.com/37643248/99881941-428dbd80-2c60-11eb-9c24-fdab5b110279.gif" width=240px> | <img src="resource/IMG_3623.PNG" width=240px> | <img src="resource/IMG_3626.PNG" width=240px> | <img src="resource/IMG_3627.PNG" width=240px> | <img src="resource/IMG_3629.PNG" width=240px> |
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -35,18 +35,25 @@ Download model from [apple's model page](https://developer.apple.com/machine-lea
 
 ### Inference Time
 
-| Device        | Inference Time | Total Time |
-| ------------- | :-----: | :-----: |
-| iPhone XS Max | **146 ms** | 155 ms |
-| iPhone XS     | **146 ms** | **151 ms** |
-| iPhone XR     | 148 ms  | 154 ms  |
-| iPhone X      | 624 ms  | 640 ms  |
-| iPhone 8+     | 621 ms  | 634 ms  |
-| iPhone 8      | 626 ms  | 639 ms  |
-| iPhone 7+     | 595 ms  | 609 ms  |
-| iPhone 7      | 612 ms  | 624 ms  |
-| iPhone 6S+    | 1038 ms | 1051 ms |
-| iPhone 6+     | 3290 ms | 3326 ms |
+| Device        | Inference Time | Total Time(GPU) | Total Time(CPU) |
+| ------------- | :-----: | :-----: | :-----------: |
+| iPhone 12 Pro Max | ⏲ | ⏲ | ⏲ |
+| iPhone 12 Pro | ⏲ | ⏲ | ⏲ |
+| iPhone 12     | ⏲ | ⏲ | ⏲ |
+| iPhone 12 Mini | ⏲ | ⏲ | ⏲ |
+| iPhone 11 Pro Max | ⏲ | ⏲ | ⏲ |
+| iPhone 11 Pro | **134 ms**  | **134 ms** | **149 ms** |
+| iPhone 11     | ⏲ | ⏲ | ⏲ |
+| iPhone SE(2nd) | ⏲ | ⏲ | ⏲ |
+| iPhone XS Max | 146 ms | ⏲ | 155 ms |
+| iPhone XS     | 146 ms | ⏲ | 151 ms |
+| iPhone XR     | 148 ms  | ⏲ | 154 ms |
+| iPhone X      | 624 ms  | ⏲ | 640 ms |
+| iPhone 8+     | 621 ms  | ⏲ | 634 ms |
+| iPhone 8      | 626 ms  | ⏲ | 639 ms |
+| iPhone 7+     | 595 ms  | ⏲ | 609 ms |
+| iPhone 7      | 612 ms  | ⏲ | 624 ms |
+| iPhone 6S+    | 1038 ms | ⏲ | 1051 ms |
 
 
 ## See also


### PR DESCRIPTION
Post-processing latency is down `15 ms` to `1 ms` using MetalKit and Accelerate framework.

![depthprediction-gpu-demo-001-1](https://user-images.githubusercontent.com/37643248/99881941-428dbd80-2c60-11eb-9c24-fdab5b110279.gif)


## Related Issue

- #1 

## PR Points

- Optimize post-processing with MetalKit and Accelerate framework
  - Add Metalkit based external library named [`MetalCamera`](https://github.com/jsharp83/MetalCamera)
  - Add `LiveMetalImageViewController`
  - Implement to convert double MLMultiArray to float Array using [`vDSP_vdpsp`](https://developer.apple.com/documentation/accelerate/1450729-vdsp_vdpsp)
  - Implement to normalize the float Array into 0.0~1.0 [`vDSP_vsbm`](https://developer.apple.com/documentation/accelerate/1449914-vdsp_vsbm?language=objc)
